### PR TITLE
Enable to set insecure option to token fetcher (UAA)

### DIFF
--- a/nozzle.go
+++ b/nozzle.go
@@ -62,8 +62,11 @@ type Config struct {
 	// access token if Token is empty.
 	Password string
 
-	// Insecure is used for insecure connection with doppler.
-	// Default value is false (Connect with TLS).
+	// Insecure is used for skipping verifying insecure connection with doppler
+	// and UAA. Default value is false, not skipping.
+	//
+	// If it true, by default, connection to doppler & UAA will be insecure.
+	// We strongly recommend not to set true instead of testing purpose.
 	Insecure bool
 
 	// DebugPrinter is noaa.DebugPrinter. It's used for debugging

--- a/token.go
+++ b/token.go
@@ -26,8 +26,8 @@ type defaultTokenFetcher struct {
 	username string
 	password string
 	timeout  time.Duration
-
-	logger *log.Logger
+	insecure bool
+	logger   *log.Logger
 }
 
 // Fetch gets access token from UAA server. This auth token
@@ -41,7 +41,7 @@ func (tf *defaultTokenFetcher) Fetch() (string, error) {
 
 	resCh, errCh := make(chan string), make(chan error)
 	go func() {
-		token, err := client.GetAuthToken(tf.username, tf.password, false)
+		token, err := client.GetAuthToken(tf.username, tf.password, tf.insecure)
 		if err != nil {
 			errCh <- err
 		}
@@ -86,6 +86,7 @@ func newDefaultTokenFetcher(config *Config) (*defaultTokenFetcher, error) {
 		timeout:  config.UaaTimeout,
 		username: config.Username,
 		password: config.Password,
+		insecure: config.Insecure,
 		logger:   config.Logger,
 	}
 


### PR DESCRIPTION
Now if you set `nozzle.Config.Insecure=true`, you can connect both doppler & UAA with skipping ssl validation (currently only doppler). 
