### PR TITLE
Use httptest for timeout test

### DIFF
--- a/token_test.go
+++ b/token_test.go
@@ -111,14 +111,20 @@ func TestDefaultTokenFetcher_failed_to_auth(t *testing.T) {
 func TestDefaultTokenFetcher_timeout(t *testing.T) {
 	t.Parallel()
 
+	// Create server it just waits for timout of client
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(1 * time.Second)
+	}))
+	defer ts.Close()
+
 	config := &Config{
-		UaaAddr:  "https://localhost",
+		UaaAddr:  ts.URL,
 		Username: "admin",
 		Password: "nipr8qhbp89pq",
 		Logger:   defaultLogger,
 
 		// Set very very very short timeout time
-		UaaTimeout: 1 * time.Nanosecond,
+		UaaTimeout: 1 * time.Millisecond,
 	}
 
 	fetcher, err := newDefaultTokenFetcher(config)


### PR DESCRIPTION
Now test on travis fails because of `TestDefaultTokenFetcher_timeout` (sometimes it works). This PR fixes that test by using `httptest`
