### PR TITLE
Disable to start consuming when creating client

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ config := &nozzle.Config{
 // Create default consumer
 consumer, _  := nozzle.NewDefaultConsumer(config)
 
+// Start consumer
+consumer.Start()
+
 // Consume events
 event := <-consumer.Events()
 ... 

--- a/example/main.go
+++ b/example/main.go
@@ -60,6 +60,9 @@ func run(args []string) int {
 		return 1
 	}
 
+	// Start consumer
+	consumer.Start()
+
 	log.Printf("[INFO] Start example producer")
 	doneCh := make(chan struct{})
 	go func() {

--- a/helper_test.go
+++ b/helper_test.go
@@ -1,0 +1,60 @@
+package nozzle
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/cloudfoundry/sonde-go/events"
+	"github.com/gogo/protobuf/proto"
+	"github.com/gorilla/websocket"
+)
+
+func NewDopplerServer(t *testing.T, inputCh <-chan []byte, authToken string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := r.Header.Get("Authorization")
+		if token != authToken {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		upgrader := websocket.Upgrader{
+			// Accept all origin
+			CheckOrigin: func(r *http.Request) bool { return true },
+		}
+
+		ws, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			// Should not reach here
+			t.Fatalf("err: %s", err)
+		}
+		defer ws.Close()
+		defer ws.WriteControl(websocket.CloseMessage, []byte(""), time.Time{})
+
+		for input := range inputCh {
+			if err := ws.WriteMessage(websocket.BinaryMessage, input); err != nil {
+				// Should not reach here
+				t.Fatalf("err: %s", err)
+			}
+		}
+	}))
+}
+
+func NewEvent(message string, timestamp int64) ([]byte, error) {
+	logMessage := &events.LogMessage{
+		Message:     []byte(message),
+		MessageType: events.LogMessage_OUT.Enum(),
+		AppId:       proto.String("my-app-guid"),
+		SourceType:  proto.String("DEA"),
+		Timestamp:   proto.Int64(timestamp),
+	}
+
+	return proto.Marshal(&events.Envelope{
+		LogMessage: logMessage,
+		EventType:  events.Envelope_LogMessage.Enum(),
+		Origin:     proto.String("fake-origin-1"),
+		Timestamp:  proto.Int64(timestamp),
+	})
+
+}

--- a/nozzle.go
+++ b/nozzle.go
@@ -91,8 +91,8 @@ type Config struct {
 // admin to fetch the token.
 //
 // It returns error if the token is empty or can not fetch token from UAA
-// If token is not empty or successfully getting from UAA, then it starts
-// to consume firehose events and detecting slowConsumerAlerts.
+// If token is not empty or successfully getting from UAA, then it returns nozzle.Consumer.
+// (In initial version, it starts consuming here but now Start() should be called).
 func NewDefaultConsumer(config *Config) (Consumer, error) {
 	if config.Logger == nil {
 		config.Logger = defaultLogger
@@ -139,24 +139,9 @@ func NewDefaultConsumer(config *Config) (Consumer, error) {
 		}
 	}
 
-	// Start consuming events from firehose.
-	eventsCh, errCh := rc.Consume()
-
-	// Construct default slowDetector
-	sd := &defaultSlowDetector{
-		logger: config.Logger,
-	}
-
-	// Start reading events from firehose and detect `slowConsumerAlert`.
-	// The detection is notified by detectCh.
-	eventsCh_, errCh_, detectCh := sd.Detect(eventsCh, errCh)
-
 	return &consumer{
-		rawConsumer:  rc,
-		slowDetector: sd,
-		eventCh:      eventsCh_,
-		errCh:        errCh_,
-		detectCh:     detectCh,
+		rawConsumer: rc,
+		logger:      config.Logger,
 	}, nil
 }
 

--- a/nozzle_test.go
+++ b/nozzle_test.go
@@ -3,9 +3,121 @@ package nozzle
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestDefaultConsumer(t *testing.T) {
+	t.Parallel()
+
+	// inputCh is used to send message from test web socket server
+	inputCh := make(chan []byte, 1)
+
+	// authToken is valid auth token used for authorizing web socket connection
+	authToken := "ncp9q3vbap98r4denpiubg"
+
+	// Setup web socket server
+	ds := NewDopplerServer(t, inputCh, authToken)
+	defer ds.Close()
+
+	config := &Config{
+		DopplerAddr:    strings.Replace(ds.URL, "http:", "ws:", 1),
+		Insecure:       true,
+		Token:          authToken,
+		SubscriptionID: "A",
+	}
+
+	consumer, err := NewDefaultConsumer(config)
+	if err != nil {
+		t.Fatalf("Expect not to err: %s", err)
+	}
+
+	// Start consuming.
+	if err := consumer.Start(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Create test message send from web socket.
+	// It will be encoded to protocol buffer.
+	timestamp := time.Now().UnixNano()
+	message := "Hello from fake loggregator"
+
+	eventBytes, err := NewEvent(message, timestamp)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Send message from doppler.
+	inputCh <- eventBytes
+
+	select {
+	case event := <-consumer.Events():
+		got := string(event.GetLogMessage().Message)
+		if got != message {
+			t.Fatalf("expect %q to be eq %q", got, message)
+		}
+	case err := <-consumer.Errors():
+		if err != nil {
+			t.Fatalf("err :%s", err)
+		}
+	case <-time.After(10 * time.Millisecond):
+		t.Fatalf("expect not timeout")
+	}
+}
+
+func TestDefaultConsumer_withoutStart(t *testing.T) {
+
+	// inputCh is used to send message from test web socket server
+	inputCh := make(chan []byte, 1)
+
+	// authToken is valid auth token used for authorizing web socket connection
+	authToken := "ncp9q3vbap98r4denpiubg"
+
+	// Setup web socket server
+	ds := NewDopplerServer(t, inputCh, authToken)
+	defer ds.Close()
+
+	config := &Config{
+		DopplerAddr:    strings.Replace(ds.URL, "http:", "ws:", 1),
+		Insecure:       true,
+		Token:          authToken,
+		SubscriptionID: "A",
+	}
+
+	// Create consumer but not start consumer
+	consumer, err := NewDefaultConsumer(config)
+	if err != nil {
+		t.Fatalf("Expect not to err: %s", err)
+	}
+
+	// Create test message send from web socket.
+	// It will be encoded to protocol buffer.
+	timestamp := time.Now().UnixNano()
+	message := "Hello from fake loggregator"
+
+	eventBytes, err := NewEvent(message, timestamp)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Send message from doppler.
+	inputCh <- eventBytes
+	received := false
+	select {
+	case <-consumer.Events():
+		received = true
+	case <-consumer.Detects():
+		received = true
+	case <-consumer.Errors():
+		received = true
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	if received {
+		t.Fatalf("expect consumer doesn't start")
+	}
+}
+
+func TestNewDefaultConsumer(t *testing.T) {
 	cases := []struct {
 		in      *Config
 		success bool


### PR DESCRIPTION
Now it starts consuming and slowConsumer detect when creates `nozzle.Client`. This is not intuitive and makes difficult to implement restart functionality on actual nozzle. 

**This will break interface**. Now you need to call `Start()` when you start consuming. 
