### PR TITLE
Unexport some interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ config := &nozzle.Config{
 }
    
 // Create default consumer
-consumer, _  := nozzle.NewDefaultConsumer(config)
+consumer, _  := nozzle.NewConsumer(config)
 
 // Start consumer
 consumer.Start()

--- a/consumer.go
+++ b/consumer.go
@@ -34,7 +34,7 @@ type Consumer interface {
 
 type consumer struct {
 	rawConsumer  RawConsumer
-	slowDetector SlowDetector
+	slowDetector slowDetector
 	logger       *log.Logger
 
 	eventCh  <-chan *events.Envelope

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -27,7 +27,7 @@ func TestConsumer_implement(t *testing.T) {
 
 func TestRawConsumer_implement(t *testing.T) {
 	// Test rawConsumer implements consumer
-	var _ RawConsumer = &rawConsumer{}
+	var _ rawConsumer = &rawDefaultConsumer{}
 }
 
 func TestRawConsumer_consume(t *testing.T) {
@@ -43,7 +43,7 @@ func TestRawConsumer_consume(t *testing.T) {
 	ts := NewDopplerServer(t, inputCh, authToken)
 	defer ts.Close()
 
-	consumer := &rawConsumer{
+	consumer := &rawDefaultConsumer{
 		dopplerAddr:    strings.Replace(ts.URL, "http:", "ws:", 1),
 		token:          authToken,
 		subscriptionID: "test-go-nozzle-A",
@@ -74,7 +74,7 @@ func TestRawConsumer_consume(t *testing.T) {
 }
 
 func TestRawConsumerClose_no_connection(t *testing.T) {
-	consumer := &rawConsumer{
+	consumer := &rawDefaultConsumer{
 		logger: log.New(ioutil.Discard, "", log.LstdFlags),
 	}
 	err := consumer.Close()
@@ -85,11 +85,11 @@ func TestRawConsumerClose_no_connection(t *testing.T) {
 
 func TestRawConsumer_validate(t *testing.T) {
 	tests := []struct {
-		in      *rawConsumer
+		in      *rawDefaultConsumer
 		success bool
 	}{
 		{
-			in: &rawConsumer{
+			in: &rawDefaultConsumer{
 				dopplerAddr:    "wss://doppler.cloudfoundry.com",
 				token:          "POrr7uofS1TOqaGCpH0skk=",
 				subscriptionID: "go-nozzle-A",
@@ -98,7 +98,7 @@ func TestRawConsumer_validate(t *testing.T) {
 		},
 
 		{
-			in: &rawConsumer{
+			in: &rawDefaultConsumer{
 				dopplerAddr:    "wss://doppler.cloudfoundry.com",
 				subscriptionID: "go-nozzle-A",
 			},
@@ -106,7 +106,7 @@ func TestRawConsumer_validate(t *testing.T) {
 		},
 
 		{
-			in:      &rawConsumer{},
+			in:      &rawDefaultConsumer{},
 			success: false,
 		},
 	}

--- a/detector.go
+++ b/detector.go
@@ -9,18 +9,18 @@ import (
 )
 
 // SlowDetectCh is channel used to send `slowConsumerAlert` event.
-type SlowDetectCh chan error
+type slowDetectCh chan error
 
 // SlowDetector defines the interface for detecting `slowConsumerAlert`
 // event. By default, defaultSlowDetetor is used. It implements same detection
 // logic as https://github.com/cloudfoundry-incubator/datadog-firehose-nozzle.
-type SlowDetector interface {
+type slowDetector interface {
 	// Detect detects `slowConsumerAlert`. It works as pipe.
 	// It receives events from upstream (RawConsumer) and inspects that events
 	// and pass it to to downstream without modification.
 	//
 	// It returns SlowDetectCh and notify `slowConsumerAlert` there.
-	Detect(<-chan *events.Envelope, <-chan error) (<-chan *events.Envelope, <-chan error, SlowDetectCh)
+	Detect(<-chan *events.Envelope, <-chan error) (<-chan *events.Envelope, <-chan error, slowDetectCh)
 
 	// Stop stops slow consumer detection. If any returns error.
 	Stop() error
@@ -33,7 +33,7 @@ type defaultSlowDetector struct {
 }
 
 // Detect start to detect `slowConsumerAlert` event.
-func (sd *defaultSlowDetector) Detect(eventCh <-chan *events.Envelope, errCh <-chan error) (<-chan *events.Envelope, <-chan error, SlowDetectCh) {
+func (sd *defaultSlowDetector) Detect(eventCh <-chan *events.Envelope, errCh <-chan error) (<-chan *events.Envelope, <-chan error, slowDetectCh) {
 	sd.logger.Println("[INFO] Start detecting slowConsumerAlert event")
 
 	// Create new channel to pass producer
@@ -45,7 +45,7 @@ func (sd *defaultSlowDetector) Detect(eventCh <-chan *events.Envelope, errCh <-c
 	sd.doneCh = make(chan struct{})
 
 	// deteCh is used to send `slowConsumerAlert` event
-	detectCh := make(SlowDetectCh)
+	detectCh := make(slowDetectCh)
 
 	// Detect from from trafficcontroller event messages
 	go func() {

--- a/detector_test.go
+++ b/detector_test.go
@@ -19,7 +19,7 @@ var (
 )
 
 func TestDefaultSlowDetector_implement(t *testing.T) {
-	var _ SlowDetector = &defaultSlowDetector{}
+	var _ slowDetector = &defaultSlowDetector{}
 }
 
 func TestDefaultSlowDetectorClose(t *testing.T) {

--- a/example/main.go
+++ b/example/main.go
@@ -54,7 +54,7 @@ func run(args []string) int {
 		Logger:         log.New(os.Stdout, "", log.LstdFlags),
 	}
 
-	consumer, err := nozzle.NewDefaultConsumer(config)
+	consumer, err := nozzle.NewConsumer(config)
 	if err != nil {
 		log.Printf("[ERROR] Failed to construct nozzle consumer: %s", err)
 		return 1

--- a/nozzle.go
+++ b/nozzle.go
@@ -79,7 +79,7 @@ type Config struct {
 	Logger *log.Logger
 
 	// The following fileds are now only for testing.
-	tokenFetcher TokenFetcher
+	tokenFetcher tokenFetcher
 	rawConsumer  RawConsumer
 }
 

--- a/nozzle.go
+++ b/nozzle.go
@@ -93,7 +93,7 @@ type Config struct {
 // It returns error if the token is empty or can not fetch token from UAA
 // If token is not empty or successfully getting from UAA, then it returns nozzle.Consumer.
 // (In initial version, it starts consuming here but now Start() should be called).
-func NewDefaultConsumer(config *Config) (Consumer, error) {
+func NewConsumer(config *Config) (Consumer, error) {
 	if config.Logger == nil {
 		config.Logger = defaultLogger
 	}
@@ -143,6 +143,11 @@ func NewDefaultConsumer(config *Config) (Consumer, error) {
 		rawConsumer: rc,
 		logger:      config.Logger,
 	}, nil
+}
+
+// Deprecated: NewDefaultConsumer is deprecated, use NewConsumer instead
+func NewDefaultConsumer(config *Config) (Consumer, error) {
+	return NewConsumer(config)
 }
 
 // maskString is used to mask string which should not be displayed

--- a/nozzle.go
+++ b/nozzle.go
@@ -80,7 +80,7 @@ type Config struct {
 
 	// The following fileds are now only for testing.
 	tokenFetcher tokenFetcher
-	rawConsumer  RawConsumer
+	rawConsumer  rawConsumer
 }
 
 // NewConsumer constructs a new consumer client for nozzle.
@@ -133,7 +133,7 @@ func NewDefaultConsumer(config *Config) (Consumer, error) {
 	rc := config.rawConsumer
 	if rc == nil {
 		var err error
-		rc, err = newRawConsumer(config)
+		rc, err = newRawDefaultConsumer(config)
 		if err != nil {
 			return nil, fmt.Errorf("failed to construct default consumer: %s", err)
 		}

--- a/nozzle_test.go
+++ b/nozzle_test.go
@@ -26,7 +26,7 @@ func TestDefaultConsumer(t *testing.T) {
 		SubscriptionID: "A",
 	}
 
-	consumer, err := NewDefaultConsumer(config)
+	consumer, err := NewConsumer(config)
 	if err != nil {
 		t.Fatalf("Expect not to err: %s", err)
 	}
@@ -84,7 +84,7 @@ func TestDefaultConsumer_withoutStart(t *testing.T) {
 	}
 
 	// Create consumer but not start consumer
-	consumer, err := NewDefaultConsumer(config)
+	consumer, err := NewConsumer(config)
 	if err != nil {
 		t.Fatalf("Expect not to err: %s", err)
 	}
@@ -186,7 +186,7 @@ func TestNewDefaultConsumer(t *testing.T) {
 	}
 
 	for i, tc := range cases {
-		_, err := NewDefaultConsumer(tc.in)
+		_, err := NewConsumer(tc.in)
 		if tc.success {
 			if err == nil {
 				// ok

--- a/token.go
+++ b/token.go
@@ -12,11 +12,11 @@ const (
 	defaultUAATimeout = 30 * time.Second
 )
 
-// TokenFetcher is the interface for fetching access token
+// tokenFetcher is the interface for fetching access token
 // From UAA server. By default, defaultTokenFetcher
 // (which is implemented with https://github.com/cloudfoundry-incubator/uaago)
 // is used
-type TokenFetcher interface {
+type tokenFetcher interface {
 	// Fetch fetches the token from Uaa and return it. If any, returns error.
 	Fetch() (string, error)
 }

--- a/token_test.go
+++ b/token_test.go
@@ -25,7 +25,7 @@ func (f *testTokenFetcher) Fetch() (string, error) {
 }
 
 func TestDefaultTokenFetcher_implement(t *testing.T) {
-	var _ TokenFetcher = &defaultTokenFetcher{}
+	var _ tokenFetcher = &defaultTokenFetcher{}
 }
 
 func TestDefaultTokenFetcher_fetch(t *testing.T) {


### PR DESCRIPTION
For future refactoring, unexport some interafeces. 

Initially, I export these interface for references (and if I get request, thinking to enable to use their own interfaces implementation inside Consumer). But it seems no. So close it. 

It should be no effects on functionality itself
