### PR TITLE
Timeout fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - 1.5.4
-  - 1.6.2
+  - 1.6.4
+  - 1.8
   - tip
 
 script:

--- a/consumer.go
+++ b/consumer.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"log"
+	"time"
 
 	noaaConsumer "github.com/cloudfoundry/noaa/consumer"
 	"github.com/cloudfoundry/sonde-go/events"
@@ -113,6 +114,7 @@ type rawDefaultConsumer struct {
 	subscriptionID string
 	insecure       bool
 	debugPrinter   noaaConsumer.DebugPrinter
+	idleTimeout    time.Duration
 
 	logger *log.Logger
 }
@@ -133,6 +135,8 @@ func (c *rawDefaultConsumer) Consume() (<-chan *events.Envelope, <-chan error) {
 	if c.debugPrinter != nil {
 		nc.SetDebugPrinter(c.debugPrinter)
 	}
+
+	nc.SetIdleTimeout(c.idleTimeout)
 
 	// Start connection
 	eventChan, errChan := nc.Firehose(c.subscriptionID, c.token)
@@ -179,6 +183,7 @@ func newRawDefaultConsumer(config *Config) (*rawDefaultConsumer, error) {
 		insecure:       config.Insecure,
 		debugPrinter:   config.DebugPrinter,
 		logger:         config.Logger,
+		idleTimeout:    config.IdleTimeout,
 	}
 
 	if err := c.validate(); err != nil {

--- a/nozzle.go
+++ b/nozzle.go
@@ -18,7 +18,7 @@ import (
 	"log"
 	"time"
 
-	noaa_consumer "github.com/cloudfoundry/noaa/consumer"
+	noaaConsumer "github.com/cloudfoundry/noaa/consumer"
 )
 
 // By default, all logs goes to ioutil.Discard.
@@ -72,7 +72,7 @@ type Config struct {
 	// DebugPrinter is noaa.DebugPrinter. It's used for debugging
 	// Noaa. Noaa is a client library to consume metric and log
 	// messages from Doppler.
-	DebugPrinter noaa_consumer.DebugPrinter
+	DebugPrinter noaaConsumer.DebugPrinter
 
 	// Logger is logger for go-nozzle. By default, output will be
 	// discarded and not be displayed.

--- a/nozzle.go
+++ b/nozzle.go
@@ -18,7 +18,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/cloudfoundry/noaa"
+	noaa_consumer "github.com/cloudfoundry/noaa/consumer"
 )
 
 // By default, all logs goes to ioutil.Discard.
@@ -72,7 +72,7 @@ type Config struct {
 	// DebugPrinter is noaa.DebugPrinter. It's used for debugging
 	// Noaa. Noaa is a client library to consume metric and log
 	// messages from Doppler.
-	DebugPrinter noaa.DebugPrinter
+	DebugPrinter noaa_consumer.DebugPrinter
 
 	// Logger is logger for go-nozzle. By default, output will be
 	// discarded and not be displayed.

--- a/nozzle.go
+++ b/nozzle.go
@@ -78,6 +78,11 @@ type Config struct {
 	// discarded and not be displayed.
 	Logger *log.Logger
 
+	// IdleTimeout is how much time to wait for a message to arrive. If no
+	// message arrives with this period, the ws connection is considered dead.
+	// If 0 (default) the timeout is disabled.
+	IdleTimeout time.Duration
+
 	// The following fileds are now only for testing.
 	tokenFetcher tokenFetcher
 	rawConsumer  rawConsumer


### PR DESCRIPTION
Currently if the websocket connection breaks silently at the TCP level noaa will simply hang forever because no [IdleTimeout](https://godoc.org/github.com/cloudfoundry/noaa/consumer#Consumer.SetIdleTimeout) has been set (see https://github.com/cloudfoundry/noaa/blob/4feaa9db10fa25a8e5c8b0aae1727e4f16dce257/consumer/async.go#L232-L235 for how it's used)

This PR allows to set IdleTimeout via a go-nozzle.Consumer config.