### PR TITLE
make consumer retryCount configurable

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -115,6 +115,7 @@ type rawDefaultConsumer struct {
 	insecure       bool
 	debugPrinter   noaaConsumer.DebugPrinter
 	idleTimeout    time.Duration
+	retryCount     int
 
 	logger *log.Logger
 }
@@ -137,6 +138,8 @@ func (c *rawDefaultConsumer) Consume() (<-chan *events.Envelope, <-chan error) {
 	}
 
 	nc.SetIdleTimeout(c.idleTimeout)
+
+	nc.SetMaxRetryCount(c.retryCount)
 
 	// Start connection
 	eventChan, errChan := nc.Firehose(c.subscriptionID, c.token)
@@ -184,6 +187,7 @@ func newRawDefaultConsumer(config *Config) (*rawDefaultConsumer, error) {
 		debugPrinter:   config.DebugPrinter,
 		logger:         config.Logger,
 		idleTimeout:    config.IdleTimeout,
+		retryCount:     config.RetryCount,
 	}
 
 	if err := c.validate(); err != nil {

--- a/nozzle.go
+++ b/nozzle.go
@@ -83,6 +83,9 @@ type Config struct {
 	// If 0 (default) the timeout is disabled.
 	IdleTimeout time.Duration
 
+	// RetryCount defines how many times consumer will retry to connect to doppler
+	RetryCount int
+
 	// The following fileds are now only for testing.
 	tokenFetcher tokenFetcher
 	rawConsumer  rawConsumer


### PR DESCRIPTION
in cloudfoundry/noaa consumer, the maxRetryCount is set to 1000 as default, which makes nozzle keeps on retrying to connect. In this we made it possible to set the maxRetryCount.