### PR TITLE
Set token refresher

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -116,7 +116,7 @@ type rawDefaultConsumer struct {
 	debugPrinter   noaaConsumer.DebugPrinter
 	idleTimeout    time.Duration
 	retryCount     int
-	tokenRefresher *defaultTokenFetcher
+	tokenRefresher tokenFetcher
 
 	logger *log.Logger
 }
@@ -141,7 +141,9 @@ func (c *rawDefaultConsumer) Consume() (<-chan *events.Envelope, <-chan error) {
 	nc.SetIdleTimeout(c.idleTimeout)
 
 	nc.SetMaxRetryCount(c.retryCount)
-	nc.RefreshTokenFrom(c.tokenRefresher)
+	if c.tokenRefresher != nil {
+	    nc.RefreshTokenFrom(c.tokenRefresher)
+	}
 
 	// Start connection
 	eventChan, errChan := nc.Firehose(c.subscriptionID, c.token)

--- a/consumer.go
+++ b/consumer.go
@@ -116,6 +116,7 @@ type rawDefaultConsumer struct {
 	debugPrinter   noaaConsumer.DebugPrinter
 	idleTimeout    time.Duration
 	retryCount     int
+	tokenRefresher *defaultTokenFetcher
 
 	logger *log.Logger
 }
@@ -140,6 +141,7 @@ func (c *rawDefaultConsumer) Consume() (<-chan *events.Envelope, <-chan error) {
 	nc.SetIdleTimeout(c.idleTimeout)
 
 	nc.SetMaxRetryCount(c.retryCount)
+	nc.RefreshTokenFrom(c.tokenRefresher)
 
 	// Start connection
 	eventChan, errChan := nc.Firehose(c.subscriptionID, c.token)
@@ -188,6 +190,7 @@ func newRawDefaultConsumer(config *Config) (*rawDefaultConsumer, error) {
 		logger:         config.Logger,
 		idleTimeout:    config.IdleTimeout,
 		retryCount:     config.RetryCount,
+		tokenRefresher: config.tokenFetcher,
 	}
 
 	if err := c.validate(); err != nil {

--- a/consumer.go
+++ b/consumer.go
@@ -115,6 +115,7 @@ type rawDefaultConsumer struct {
 	insecure       bool
 	debugPrinter   noaaConsumer.DebugPrinter
 	idleTimeout    time.Duration
+	retryCount     int
 
 	logger *log.Logger
 }
@@ -137,6 +138,8 @@ func (c *rawDefaultConsumer) Consume() (<-chan *events.Envelope, <-chan error) {
 	}
 
 	nc.SetIdleTimeout(c.idleTimeout)
+
+	nc.SetMaxRetryCount(c.retryCount)
 
 	// Start connection
 	eventChan, errChan := nc.Firehose(c.subscriptionID, c.token)
@@ -184,6 +187,7 @@ func newRawDefaultConsumer(config *Config) (*rawDefaultConsumer, error) {
 		debugPrinter:   config.DebugPrinter,
 		logger:         config.Logger,
 		idleTimeout:    config.IdleTimeout,
+		retryCount:     config.RetryCount,
 	}
 
 	if err := c.validate(); err != nil {

--- a/nozzle.go
+++ b/nozzle.go
@@ -88,7 +88,7 @@ type Config struct {
 
 	// tokenFetcher provides function to get a token, and will be used by noaa consumer
 	// to refresh a token when it is expired
-	tokenFetcher *defaultTokenFetcher
+	tokenFetcher tokenFetcher
 
 	// The following fileds are now only for testing.
 	rawConsumer rawConsumer
@@ -109,23 +109,22 @@ func NewConsumer(config *Config) (Consumer, error) {
 		config.Logger = defaultLogger
 	}
 
-	if config.tokenFetcher == nil {
-		fetcher, err := newDefaultTokenFetcher(config)
-		if err != nil {
-			return nil, fmt.Errorf("failed to construct default token fetcher: %s", err)
-		}
-		config.tokenFetcher = fetcher
-	}
-
 	// If Token is not provided, fetch it by tokenFetcher.
 	if config.Token != "" {
 		config.Logger.Printf("[DEBUG] Using auth token (%s)",
 			maskString(config.Token))
 	} else {
-
 		if config.UaaAddr == "" {
 			return nil, fmt.Errorf("both Token and UaaAddr can not be empty")
 		}
+
+	    if config.tokenFetcher == nil {
+		    fetcher, err := newDefaultTokenFetcher(config)
+		    if err != nil {
+			    return nil, fmt.Errorf("failed to construct default token fetcher: %s", err)
+		    }
+		    config.tokenFetcher = fetcher
+	    }
 
 		// Execute tokenFetcher and get token
 		token, err := config.tokenFetcher.Fetch()

--- a/nozzle.go
+++ b/nozzle.go
@@ -83,6 +83,9 @@ type Config struct {
 	// If 0 (default) the timeout is disabled.
 	IdleTimeout time.Duration
 
+	// RetryCount defines how many times consumer will retry to connect to doppler
+	RetryCount int
+
 	// The following fileds are now only for testing.
 	tokenFetcher tokenFetcher
 	rawConsumer  rawConsumer

--- a/token.go
+++ b/token.go
@@ -80,6 +80,12 @@ func (tf *defaultTokenFetcher) validate() error {
 	return nil
 }
 
+// implement the interface of new noaa token_refresher
+// to get a new token when the existing one is expired
+func (tf *defaultTokenFetcher) RefreshAuthToken() (string, error) {
+	return tf.Fetch()
+}
+
 func newDefaultTokenFetcher(config *Config) (*defaultTokenFetcher, error) {
 	fetcher := &defaultTokenFetcher{
 		uaaAddr:  config.UaaAddr,

--- a/token.go
+++ b/token.go
@@ -19,6 +19,8 @@ const (
 type tokenFetcher interface {
 	// Fetch fetches the token from Uaa and return it. If any, returns error.
 	Fetch() (string, error)
+	RefreshAuthToken() (string, error)
+
 }
 
 type defaultTokenFetcher struct {

--- a/token_test.go
+++ b/token_test.go
@@ -24,6 +24,10 @@ func (f *testTokenFetcher) Fetch() (string, error) {
 	return f.Token, nil
 }
 
+func (f *testTokenFetcher) RefreshAuthToken() (string, error) {
+	 return f.Fetch()
+}
+
 func TestDefaultTokenFetcher_implement(t *testing.T) {
 	var _ tokenFetcher = &defaultTokenFetcher{}
 }


### PR DESCRIPTION
new noaa lib provides logic to refresh token when it is expired.
in this PR, we implement the interface so that new token will be issued.

PS:   the retryCount commit is also included.